### PR TITLE
Bugfix in mcmc.m

### DIFF
--- a/mcmc.m
+++ b/mcmc.m
@@ -172,7 +172,7 @@ classdef mcmc < handle
             for i = 1:numel(names)
                temp = cat(1,self.samples.(names{i})); %VERTCAT???
                sz = size(temp);
-               temp = temp(self.permute_index(1:max(sz)),:);
+               temp = temp(self.permute_index(1:sz(1)),:);
                out.(names{i}) = reshape(temp,sz);
             end
             % TODO: check that this is expected behavior!!


### PR DESCRIPTION
Fixed a small bug in mcmc.m. Previously the program crashed in the (rare) case where the number of posterior samples was smaller than the number of parameters in the model, because of an indexing error.
