### PR TITLE
Fix issue 61: checking Stan version: https://github.com/brian-lau/Mat…

### DIFF
--- a/StanModel.m
+++ b/StanModel.m
@@ -927,8 +927,8 @@ classdef StanModel < handle
                             'pollInterval',0.005);
          p.block(0.05);
          if p.exitValue == 0
-            str = regexp(p.stdout{1},'\ ','split');
-            ver = cellfun(@str2num,regexp(str{3},'\.','split'));
+            str = regexp(p.stdout{1},'(?<=v)[0-9\.]+', 'match');
+            ver = cellfun(@str2num,regexp(str{1},'\.','split'));
          else
             fprintf('%s\n',p.stdout{:});
          end


### PR DESCRIPTION
Fixes issue 61:

The regex to check the cmdstan version is broken, but the suggestion in the issue did not resolve the issue on Centos.

The regex to check the Stan version will be more robust if we:
   1) *match* on the first string of numerals and dots following a "v": '(?<=v)[0-9\.]+'
   2) *split* on "." and cast the chunks to integers as before

 On branch master
 Changes to be committed:
	modified:   StanModel.m